### PR TITLE
first turn movement restriction #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 .vscode
+*.ipynb
+*.ipynb_checkpoints/

--- a/game/game_state.py
+++ b/game/game_state.py
@@ -53,6 +53,7 @@ class GameState:
             [1, 1, 2, 1, 1]
         ], dtype=np.int8)
         self.turn = 1  # +が先攻
+        self.n_turns = 0  # ターン経過数
 
     def to_inputs(self, flip=False) -> np.ndarray:
         """強化学習用の入力
@@ -75,6 +76,8 @@ class GameState:
 
     def move(self, i: int, j: int, drc: Drc) -> Winner:
         """drcへの移動"""
+        if self.n_turns == 0 and drc == Drc.f2:
+            raise ChoiceOfMovementError(f"先手の初手は2マス移動不可")
         if self.board[i, j] != self.turn:
             raise ChoiceOfMovementError(f"選択したコマが王か色違いか存在しない {i, j}")
         direction = self.directionize(drc)
@@ -94,6 +97,8 @@ class GameState:
 
     def move_d_vec(self, i: int, j: int, direction: np.array) -> Winner:
         """directionのベクトル方向への移動"""
+        if self.n_turns == 0 and direction[0] == -2:
+            raise ChoiceOfMovementError(f"先手の初手は2マス移動不可")
         if direction[0] == 2 * self.turn:
             raise ChoiceOfMovementError(f"後ろ2コマ移動不可{direction}")
         if abs(direction[0]) == 2 and direction[1] != 0:
@@ -129,6 +134,7 @@ class GameState:
             elif (self.board != 1).all():
                 return Winner.minus  # 後手勝利
         self.turn *= -1
+        self.n_turns += 1
         return Winner.not_ended
 
     def directionize(self, drc: Drc) -> np.ndarray:

--- a/tests/test_first_turn_movement.py
+++ b/tests/test_first_turn_movement.py
@@ -1,0 +1,31 @@
+import sys
+import unittest
+from game.game_state import GameState, Drc
+sys.path.append('../')
+from game.errors import ChoiceOfMovementError
+
+
+class TestFirstTurmMovement(unittest.TestCase):
+
+    def setUp(self):
+        self.gs = GameState()
+
+    def test_first_move_front2(self):
+        with self.assertRaises(ChoiceOfMovementError):
+            self.gs.move_d_vec(6, 0, [-2, 0])
+        with self.assertRaises(ChoiceOfMovementError):
+            self.gs.move_d_vec(5, 1, [-2, 0])
+        with self.assertRaises(ChoiceOfMovementError):
+            self.gs.move_d_vec(6, 2, [-2, 0])
+        with self.assertRaises(ChoiceOfMovementError):
+            self.gs.move_d_vec(5, 3, [-2, 0])
+        with self.assertRaises(ChoiceOfMovementError):
+            self.gs.move_d_vec(6, 4, [-2, 0])
+
+    def test_random_play_first_move(self):
+        valid_Drcs = (Drc.B_fr, Drc.B_r, Drc.B_f, Drc.B_fl, Drc.B_l)
+            # possible direction for first movement
+        for _ in range(1000):
+            self.setUp()
+            __, outputs_index = self.gs.random_play()
+            self.assertTrue(outputs_index % 9 in valid_Drcs)


### PR DESCRIPTION
- 先攻初手のみ，2マス移動をできなくする
    - 先攻が人間の場合と，ランダムの場合を修正
    - 先攻がMLの場合は未実装なので，このコミットでの変更はない
        -> モデルが先攻の学習の実装時に思い出す必要がある

- guiでの手動テスト + unittestでのテストは行った